### PR TITLE
error correction: navigateTo argument has to be a string, not an object

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -23,7 +23,7 @@ function(
                     onClick: function() {
                         var ret = browser.view.visibleRegion();
                         browser.config.reverseComplement = this.get('checked');
-                        browser.navigateTo({ ref: ret.ref, start: Math.round(browser.refSeq.length - ret.end), end: Math.round(browser.refSeq.length - ret.start)});
+                        browser.navigateTo( ret.ref + ":" + Math.round(browser.refSeq.length - ret.end) + ".." + Math.round(browser.refSeq.length - ret.start));
                         browser.view.redrawTracks();
                     }
                 }));


### PR DESCRIPTION
Hello,

Thank you for your plugin, that is exactly what I was looking for!

I noticed, that when we tick the view->Reverse complement view, there was a toLowerCase error in the src/JBrowse/Browser.js. The navigateTo argument had to be a string (like this example: Sc0000000:1056259..5284870) and not an object.
So I corrected this error in my branch.

I also noticed that the plugin was not adapted for the recent functionality of View->Search features.
I did corrections in the JBrowse core (in src/JBrowse/View/Dialog/Search.js) and this works. But do you know how I could do these corrections within your plugin without doing corrections to the JBrowse core?

Best,

Adrien